### PR TITLE
Consistent attribute order for links

### DIFF
--- a/Favicon HTML-Browser XML Generator Bookmark.webloc
+++ b/Favicon HTML-Browser XML Generator Bookmark.webloc
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>URL</key>
-	<string>http://codepen.io/fuzzywalrus/pen/BWWMjJ/</string>
+	<string>https://codepen.io/antonyoneill/pen/XeYzeo</string>
 </dict>
 </plist>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,7 +32,7 @@ To use these icons, will want to include in the `<head></head>` of your html fil
 <link rel="icon" href="/path/to/favicon-128.png" sizes="128x128">
 <link rel="icon" href="/path/to/favicon-228.png" sizes="228x228">
 <!-- Android -->
-<link rel="shortcut icon" sizes="196x196" href="/path/to/favicon-196.png">
+<link rel="shortcut icon" href="/path/to/favicon-196.png" sizes="196x196">
 <!-- iOS -->
 <link rel="apple-touch-icon" href="/path/to/favicon-120.png" sizes="120x120">
 <link rel="apple-touch-icon"  href="path/to/favicon-152.png" sizes="152x152">


### PR DESCRIPTION
Hi there,

Great work creating this generator and the Photoshop Action! We've used the generator at work and the result is great, however as someone with mild OCD I couldn't help but notice that the sizes attribute is after the href attribute in all the links, except the android one.

Would you consider merging this in?

I forked the codepen, but you're welcome to update your own.

Thanks